### PR TITLE
Use nnoremap, vnoremap

### DIFF
--- a/plugin/translator.vim
+++ b/plugin/translator.vim
@@ -42,13 +42,13 @@ else
   let g:translator_default_engines = get(g:, 'translator_default_engines', ['google', 'bing'])
 endif
 
-nmap <silent> <Plug>Translate   :call translator#translate('echo', v:false, '-t ' . expand('<cword>'), '')<CR>
-vmap <silent> <Plug>TranslateV  :<C-U>call translator#translate('echo', v:true, '', '')<CR>
-nmap <silent> <Plug>TranslateW  :call translator#translate('window', v:false, '-t ' . expand('<cword>'), '')<CR>
-vmap <silent> <Plug>TranslateWV :<C-U>call translator#translate('window', v:true, '', '')<CR>
-nmap <silent> <Plug>TranslateR  viw:<C-U>call translator#translate('replace', v:false, '', '')<CR>
-vmap <silent> <Plug>TranslateRV :<C-U>call translator#translate('replace', v:true, '', '')<CR>
-nmap <silent> <Plug>TranslateH  :call translator#history#export()
+nnoremap <silent> <Plug>Translate   :call translator#translate('echo', v:false, '-t ' . expand('<cword>'), '')<CR>
+vnoremap <silent> <Plug>TranslateV  :<C-U>call translator#translate('echo', v:true, '', '')<CR>
+nnoremap <silent> <Plug>TranslateW  :call translator#translate('window', v:false, '-t ' . expand('<cword>'), '')<CR>
+vnoremap <silent> <Plug>TranslateWV :<C-U>call translator#translate('window', v:true, '', '')<CR>
+nnoremap <silent> <Plug>TranslateR  viw:<C-U>call translator#translate('replace', v:false, '', '')<CR>
+vnoremap <silent> <Plug>TranslateRV :<C-U>call translator#translate('replace', v:true, '', '')<CR>
+nnoremap <silent> <Plug>TranslateH  :call translator#history#export()
 
 if !exists(':Translate')
   command! -complete=customlist,translator#cmdline#complete -nargs=* -bang -range


### PR DESCRIPTION
The following doesn't work now.

```vim
set runtimepath+=/path/to/vim-translator
xnoremap : ;
vmap T <Plug>TranslateV
```

This pull-request will fix it.
