### PR TITLE
Add langdetect

### DIFF
--- a/script/translator.py
+++ b/script/translator.py
@@ -9,6 +9,7 @@ import copy
 import json
 import argparse
 import codecs
+import langdetect
 
 if sys.version_info[0] < 3:
     is_py3 = False
@@ -383,7 +384,7 @@ class SdcvShell(BasicTranslator):
     def __init__(self, name="sdcv"):
         super(SdcvShell, self).__init__(name)
 
-    def get_dictionary(self, sl, tl):
+    def get_dictionary(self, sl, tl, text):
         """get dictionary of sdcv
 
         :sl: source_lang
@@ -392,9 +393,12 @@ class SdcvShell(BasicTranslator):
 
         """
         dictionary = ''
+        if sl == '':
+            sl = langdetect.detect(text)
+
         if (sl == 'en') & (tl == 'zh'):
             dictionary = '朗道英汉字典5.0'
-        elif (sl == 'zh') & (tl == 'en'):
+        elif (sl == 'zh_cn') & (tl == 'en'):
             dictionary = '朗道汉英字典5.0'
         elif (sl == 'en') & (tl == 'ja'):
             dictionary = 'jmdict-en-ja'
@@ -410,7 +414,7 @@ class SdcvShell(BasicTranslator):
             options.append("-proxy {}".format(self._proxy_url))
 
         source_lang = "" if sl == "auto" else sl
-        dictionary = self.get_dictionary(sl, tl)
+        dictionary = self.get_dictionary(source_lang, tl, text)
         if dictionary == '':
             default_opts = [
             ]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32936898/79068561-7aac4580-7cfa-11ea-9baf-e8beefaec4ce.png)

1. i notice langdetect is not always ok, it is not 100% correct.
2. not all users install langdetect. if someone don't, should use v:lang to replace.(my v:lang is zh_CN.utf8)
3. if possible, user should can defind a global variable to decide use which dictionary for source language and target language.
4. had better distinguish zh_CN and zh_TW, langdetect and sdcv don't think they are the same.

![image](https://user-images.githubusercontent.com/32936898/79068646-1b9b0080-7cfb-11ea-981a-465167bf8e81.png)
