### PR TITLE
Fix popup-window display

### DIFF
--- a/autoload/translator/util.vim
+++ b/autoload/translator/util.vim
@@ -51,9 +51,12 @@ endfunction
 
 function! translator#util#padding(text, width, char) abort
   let padding_size = (a:width - strdisplaywidth(a:text)) / 2
-  let padding = repeat(a:char, padding_size)
+  let padding = repeat(a:char, padding_size / strdisplaywidth(a:char))
   let padend = repeat(a:char, (a:width - strdisplaywidth(a:text)) % 2)
-  let text = padding . a:text . padding . padend
+  let text = padding . a:text . padding
+  if a:width >= strdisplaywidth(text) + strdisplaywidth(padend)
+    let text .= padend
+  endif
   return text
 endfunction
 


### PR DESCRIPTION
Thanks for the great plugin!

If `set ambiwidth=double` is set, some fonts may not be displayed correctly.
This has been fixed.

I am using a Japanese font called [Cica](https://github.com/miiton/Cica).

* OS: Windows 10
* Vim 8.2

Before:
<img width="350" alt="double_display" src="https://user-images.githubusercontent.com/16581287/90312800-62676400-df42-11ea-82b6-7681b86039af.png">

After:
<img width="350" alt="fixed" src="https://user-images.githubusercontent.com/16581287/90312904-1f59c080-df43-11ea-9baa-d685c17763e9.png">


Thank you!