### PR TITLE
fix sentence translation bug in vim8

### DIFF
--- a/autoload/translator/util.vim
+++ b/autoload/translator/util.vim
@@ -153,6 +153,7 @@ function! translator#util#text_proc(text) abort
   let text = substitute(text, "\n\r", ' ', 'g')
   let text = substitute(text, '\v^\s+', '', '')
   let text = substitute(text, '\v\s+$', '', '')
-  let text = shellescape(text)
+  let text = escape(text, '"')
+  let text = printf('"%s"', text)
   return text
 endfunction


### PR DESCRIPTION
修复vim8下的句子翻译错误，修复方案来自于 #24 @zhmars 。