### PR TITLE
Fix not to use shell

### DIFF
--- a/autoload/translator.vim
+++ b/autoload/translator.vim
@@ -34,21 +34,21 @@ function! translator#start(displaymode, bang, range, line1, line2, argstr) abort
 endfunction
 
 function! translator#translate(options, displaymode) abort
-  let cmd = printf(
-    \ '%s %s --engines %s --target_lang %s --source_lang %s %s',
+  let cmd = [
     \ s:python_executable,
     \ s:py_file,
-    \ join(a:options.engines, ' '),
-    \ a:options.target_lang,
-    \ a:options.source_lang,
-    \ a:options.text
-    \ )
+    \ '--target_lang', a:options.target_lang,
+    \ '--source_lang', a:options.source_lang,
+    \ a:options.text,
+    \ '--engines'
+    \ ]
+  \ + a:options.engines 
   if !empty(g:translator_proxy_url)
-    let cmd .= printf(' --proxy %s', g:translator_proxy_url)
+    let cmd += ['--proxy', g:translator_proxy_url]
   endif
   if match(a:options.engines, 'trans') >= 0
-    let cmd .= printf(" --options='%s'", join(g:translator_translate_shell_options, ','))
+    let cmd += [printf("--options='%s'", join(g:translator_translate_shell_options, ','))]
   endif
-  call translator#logger#log(cmd)
+  call translator#logger#log(join(cmd, ' '))
   call translator#job#jobstart(cmd, a:displaymode)
 endfunction


### PR DESCRIPTION
## Problem

Translating text including backquote causes error.

For example,
```
`one` is 1
```

### log by `call translator#logger#open_log()`

```
@function translator#start[4]..translator#translate[16]..translator#logger#log
/usr/bin/python3 /home/notomo/.vim/minpac/pack/minpac/start/vim-translator/autoload/../script/translator.py --engines google --target_lang ja --source_lang auto "`one` is 1"

@function <SNR>222_on_stdout_nvim[1]..<SNR>222_start[12]..translator#logger#log
zsh:1: command not found: one 

@function <SNR>222_on_stdout_nvim[1]..<SNR>222_start[22]..translator#logger#log
zsh:1: command not found: one 

@function <SNR>222_on_stdout_nvim[1]..<SNR>222_start[12]..translator#logger#log
{"text": "is 1", "status": 1, "results": [{"engine": "google", "phonetic": "", "paraphrase": "\u306f1\u3067\u3059", "explain": []}]}

@function <SNR>222_on_stdout_nvim[1]..<SNR>222_start[22]..translator#logger#log
{"text": "is 1", "status": 1, "results": [{"engine": "google", "phonetic": "", "paraphrase": "は1です", "explain": []}]}
```

## Solution

Run cmd directly (no 'shell').

ref.
- `:h job_start()` in vim
- `:h jobstart()` in neovim
