### PR TITLE
Do not reread the current file when creating a preview window

### DIFF
--- a/autoload/translator/window/preview.vim
+++ b/autoload/translator/window/preview.vim
@@ -25,7 +25,8 @@ let s:winid = -1
 function! translator#window#preview#create(linelist, configs) abort
   call s:win_close_preview()
   let curr_pos = getpos('.')
-  execute 'noswapfile bo pedit!'
+  noswapfile bo new
+  set previewwindow
   call setpos('.', curr_pos)
   wincmd P
   execute a:configs.height + 1 . 'wincmd _'


### PR DESCRIPTION
Fixes #86 

Preview window was being created using `:pedit` command
It caused the current file to be reread, as if with `:edit`
Now the window is created with a new buffer using `:new` and setting `'previewwindow'` afterwards