### PR TITLE
Fixed utf-8 encoding exception when receiving partial multi-byte encoded character from visual blocks selection.

### DIFF
--- a/script/translator.py
+++ b/script/translator.py
@@ -579,6 +579,16 @@ ENGINES = {
 }
 
 
+def sanitize_input_text(text):
+    while True:
+        try:
+            text.encode()
+            break
+        except UnicodeEncodeError:
+            text = text[:-1]
+    return text
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--engines", nargs="+", required=False, default=["google"])
@@ -588,6 +598,8 @@ def main():
     parser.add_argument("--options", type=str, default=None, required=False)
     parser.add_argument("text", nargs="+", type=str)
     args = parser.parse_args()
+
+    args.text = [ sanitize_input_text(x) for x in args.text ]
 
     text = " ".join(args.text).strip("'").strip('"').strip()
     text = re.sub(r"([a-z])([A-Z][a-z])", r"\1 \2", text)


### PR DESCRIPTION
Not 100% sure, but this could be related to #70, since when you select a visual block from vim, some multi-byte encoded characters are split, which means an exception will be thrown any time you try to ".encode()" the input text, since it's no longer valid utf-8.